### PR TITLE
forgot to add "--forceTableScan" to mongoexport cmd. Using "forceTabl…

### DIFF
--- a/src/main/java/fr/ans/psc/pscextract/service/ExtractionService.java
+++ b/src/main/java/fr/ans/psc/pscextract/service/ExtractionService.java
@@ -160,7 +160,8 @@ public class ExtractionService {
                 "--host=" + mongoAddr + " " +
                 "--fields=" + fields + " " +
                 "--type=csv " +
-                "--out=" + getFilePath(extractName);
+                "--out=" + getFilePath(extractName) +
+                "--forceTableScan";
 
         log.info("running command : {}", cmd);
         log.info("exporting schema {}", outCollection);


### PR DESCRIPTION
…eScan" will prevent the snapshot functionality to become active